### PR TITLE
Ds_Merchant_Identifier may not be present because it is optional

### DIFF
--- a/src/Redsys/Fake/Fake.php
+++ b/src/Redsys/Fake/Fake.php
@@ -167,7 +167,7 @@ class Fake
             $post['Ds_ErrorCode'] = $_POST['Ds_ErrorCode'];
         }
 
-        if ($values['Ds_Merchant_Identifier'] == 'REQUIRED') {
+        if (array_key_exists('Ds_Merchant_Identifier', $values) && $values['Ds_Merchant_Identifier'] == 'REQUIRED') {
             $post['Ds_Merchant_Identifier'] = $this->generateRandomIdentifier();
             $post['Ds_Card_Number'] = mt_rand(1000, 9999).'********'.mt_rand(1000, 9999);
             $post['Ds_Card_Brand'] = mt_rand(1, 3);
@@ -189,7 +189,7 @@ class Fake
     private function getSignature($type, $values)
     {
         if (!in_array($type, array('check', 'new'), true)) {
-              $this->setError(sprintf('Signature type <strong>%s</strong> is not valid', $type));
+            $this->setError(sprintf('Signature type <strong>%s</strong> is not valid', $type));
         }
 
         if ($type == 'check') {


### PR DESCRIPTION
Hi @eusonlito,

This is a stupid change because it just fixes this notice message.

`Notice: Undefined index: Ds_Merchant_Identifier in /Users/daniel/Work/redsys-fake/src/Redsys/Fake/Fake.php on line 170`

Everything works anyway so you can dismiss it.

I found it trying to debug why my website is not receiving the request on the MerchantURL, finally, it was a 419 HTTP code from laravel because CSRF.

Maybe you want to merge it or bear in mind for the future.

Regards and thank you for this project, it is awesome to test the payments system without having the merchant information and also in your local environment!